### PR TITLE
Close directory if no .SYSTEM file found to chain to

### DIFF
--- a/inc/driver_preamble.inc
+++ b/inc/driver_preamble.inc
@@ -323,6 +323,7 @@ handle_sys_file:
         jmp     invoke_system_file
 
 not_found:
+        MLI_CALL CLOSE, close_params
         jmp     quit
 .endproc
 


### PR DESCRIPTION
If you run off the end of the chain of `.SYSTEM` files, the loader tries to invoke the quit handler, but it will soon crash with a `RESTART SYSTEM-$0B` when it also tries to open the directory (possibly "dumb" quit handlers would be fine, but Bitsy Bye isn't happy with it).

Possibly `on_error` needs to do something too, but I didn't investigate much.