### PR TITLE
Add text mode color themes

### DIFF
--- a/textcolors/Makefile
+++ b/textcolors/Makefile
@@ -1,0 +1,44 @@
+
+CAFLAGS = --target apple2enh --list-bytes 0
+LDFLAGS = --config apple2-asm.cfg
+
+OUTDIR = out
+
+HEADERS = $(wildcard *.inc) $(wildcard ../inc/*.inc)
+
+TARGETS = \
+	$(OUTDIR)/a2green.system.SYS \
+	$(OUTDIR)/bw.system.SYS \
+	$(OUTDIR)/deepblue.system.SYS \
+	$(OUTDIR)/gray.system.SYS \
+	$(OUTDIR)/gsblue.system.SYS \
+	$(OUTDIR)/mint.system.SYS \
+	$(OUTDIR)/pink.system.SYS \
+	$(OUTDIR)/wb.system.SYS
+# For timestamps
+MM = $(shell date "+%-m")
+DD = $(shell date "+%-d")
+YY = $(shell date "+%-y")
+DEFINES = -D DD=$(DD) -D MM=$(MM) -D YY=$(YY)
+
+XATTR := $(shell command -v xattr 2> /dev/null)
+
+.PHONY: clean all
+all: $(OUTDIR) $(TARGETS)
+
+$(OUTDIR):
+	mkdir -p $(OUTDIR)
+
+clean:
+	rm -f $(OUTDIR)/*.o
+	rm -f $(OUTDIR)/*.list
+	rm -f $(TARGETS)
+
+$(OUTDIR)/%.o: %.s $(HEADERS)
+	ca65 $(CAFLAGS) $(DEFINES) --listing $(basename $@).list -o $@ $<
+
+$(OUTDIR)/%.BIN $(OUTDIR)/%.SYS: $(OUTDIR)/%.o
+	ld65 $(LDFLAGS) -o $@ $<
+ifdef XATTR
+	xattr -wx prodos.AuxType '00 20' $@
+endif

--- a/textcolors/README.md
+++ b/textcolors/README.md
@@ -1,0 +1,33 @@
+# Text Color Utilities
+These utilities will work with the Apple IIgs or on any Apple II equipped with a VidHD card. Each will set the color of the text, background, and border and then invoke the ProDOS quit handler immediately.
+
+Useful if you'd like to automatically set a theme at boot or select one manually afterwards. Originally created because I wanted my GS to use a different set of colors when booting my ProDOS 8 partition then what I have set as default in the Control Panel.
+
+To have these themes applied at boot, place one of the theme SYSTEM at the end of your load chain.
+
+---
+
+[A2GREEN.SYSTEM](a2green.system.s)
+  * Apple Monitor II green phosphor theme
+
+[BW.SYSTEM](bw.system.s)
+  * White text on black background
+
+[DEEPBLUE.SYSTEM](deepblue.system.s)
+  * White text on deep blue background
+
+[GRAY.SYSTEM](gray.system.s)
+  * Dark gray text on light gray background
+
+[GSBLUE.SYSTEM](gsblue.system.s)
+  * The Apple IIgs system defaults
+
+[MINT.SYSTEM](mint.system.s)
+  * A minty flavored theme
+
+[PINK.SYSTEM](pink.system.s)
+  * Dark gray text on a pink background with light blue borders
+
+[WB.SYSTEM](wb.system.s)
+  * Black text on a black background
+

--- a/textcolors/a2green.system.s
+++ b/textcolors/a2green.system.s
@@ -1,0 +1,26 @@
+                .setcpu "6502"
+                .include "apple2.inc"
+                
+                .include "../inc/apple2.inc"
+                .include "../inc/prodos.inc"
+                
+                .org    SYS_ADDR
+                
+                cld
+                bit     ROMIN2
+                sta     CLR80VID
+                sta     CLRALTCHAR
+                sta     CLR80COL
+                jsr     SETVID
+                jsr     SETKBD
+                jsr     SETNORM
+                jsr     INIT
+                jsr     HOME
+                lda #$C0
+                sta $c022
+                lda #$00
+                sta $c034
+                MLI_CALL QUIT, quit_params
+                brk
+                
+                DEFINE_QUIT_PARAMS quit_params

--- a/textcolors/bw.system.s
+++ b/textcolors/bw.system.s
@@ -1,0 +1,26 @@
+                .setcpu "6502"
+                .include "apple2.inc"
+                
+                .include "../inc/apple2.inc"
+                .include "../inc/prodos.inc"
+                
+                .org    SYS_ADDR
+                
+                cld
+                bit     ROMIN2
+                sta     CLR80VID
+                sta     CLRALTCHAR
+                sta     CLR80COL
+                jsr     SETVID
+                jsr     SETKBD
+                jsr     SETNORM
+                jsr     INIT
+                jsr     HOME
+                lda #$0f
+                sta $c022
+                lda #$0f
+                sta $c034
+                MLI_CALL QUIT, quit_params
+                brk
+                
+                DEFINE_QUIT_PARAMS quit_params

--- a/textcolors/deepblue.system.s
+++ b/textcolors/deepblue.system.s
@@ -1,0 +1,26 @@
+                .setcpu "6502"
+                .include "apple2.inc"
+                
+                .include "../inc/apple2.inc"
+                .include "../inc/prodos.inc"
+                
+                .org    SYS_ADDR
+                
+                cld
+                bit     ROMIN2
+                sta     CLR80VID
+                sta     CLRALTCHAR
+                sta     CLR80COL
+                jsr     SETVID
+                jsr     SETKBD
+                jsr     SETNORM
+                jsr     INIT
+                jsr     HOME
+                lda #$f2
+                sta $c022
+                lda #$02
+                sta $c034
+                MLI_CALL QUIT, quit_params
+                brk
+                
+                DEFINE_QUIT_PARAMS quit_params

--- a/textcolors/gray.system.s
+++ b/textcolors/gray.system.s
@@ -1,0 +1,26 @@
+                .setcpu "6502"
+                .include "apple2.inc"
+                
+                .include "../inc/apple2.inc"
+                .include "../inc/prodos.inc"
+                
+                .org    SYS_ADDR
+                
+                cld
+                bit     ROMIN2
+                sta     CLR80VID
+                sta     CLRALTCHAR
+                sta     CLR80COL
+                jsr     SETVID
+                jsr     SETKBD
+                jsr     SETNORM
+                jsr     INIT
+                jsr     HOME
+                lda #$5a
+                sta $c022        
+                lda #$0a 
+                sta $c034  
+                MLI_CALL QUIT, quit_params
+                brk
+                
+                DEFINE_QUIT_PARAMS quit_params

--- a/textcolors/gsblue.system.s
+++ b/textcolors/gsblue.system.s
@@ -1,0 +1,26 @@
+                .setcpu "6502"
+                .include "apple2.inc"
+                
+                .include "../inc/apple2.inc"
+                .include "../inc/prodos.inc"
+                
+                .org    SYS_ADDR
+                
+                cld
+                bit     ROMIN2
+                sta     CLR80VID
+                sta     CLRALTCHAR
+                sta     CLR80COL
+                jsr     SETVID
+                jsr     SETKBD
+                jsr     SETNORM
+                jsr     INIT
+                jsr     HOME
+                lda #$f6
+                sta $c022
+                lda #$06
+                sta $c034  
+                MLI_CALL QUIT, quit_params
+                brk
+                
+                DEFINE_QUIT_PARAMS quit_params

--- a/textcolors/mint.system.s
+++ b/textcolors/mint.system.s
@@ -1,0 +1,26 @@
+                .setcpu "6502"
+                .include "apple2.inc"
+                
+                .include "../inc/apple2.inc"
+                .include "../inc/prodos.inc"
+                
+                .org    SYS_ADDR
+                
+                cld
+                bit     ROMIN2
+                sta     CLR80VID
+                sta     CLRALTCHAR
+                sta     CLR80COL
+                jsr     SETVID
+                jsr     SETKBD
+                jsr     SETNORM
+                jsr     INIT
+                jsr     HOME
+                lda #$2e
+                sta $c022
+                lda #$0e
+                sta $c034 
+                MLI_CALL QUIT, quit_params
+                brk
+                
+                DEFINE_QUIT_PARAMS quit_params

--- a/textcolors/pink.system.s
+++ b/textcolors/pink.system.s
@@ -1,0 +1,26 @@
+                .setcpu "6502"
+                .include "apple2.inc"
+                
+                .include "../inc/apple2.inc"
+                .include "../inc/prodos.inc"
+                
+                .org    SYS_ADDR
+                
+                cld
+                bit     ROMIN2
+                sta     CLR80VID
+                sta     CLRALTCHAR
+                sta     CLR80COL
+                jsr     SETVID
+                jsr     SETKBD
+                jsr     SETNORM
+                jsr     INIT
+                jsr     HOME
+                lda #$5b
+                sta $c022
+                lda #$07
+                sta $c034
+                MLI_CALL QUIT, quit_params
+                brk
+                
+                DEFINE_QUIT_PARAMS quit_params

--- a/textcolors/wb.system.s
+++ b/textcolors/wb.system.s
@@ -1,0 +1,26 @@
+                .setcpu "6502"
+                .include "apple2.inc"
+                
+                .include "../inc/apple2.inc"
+                .include "../inc/prodos.inc"
+                
+                .org    SYS_ADDR
+                
+                cld
+                bit     ROMIN2
+                sta     CLR80VID
+                sta     CLRALTCHAR
+                sta     CLR80COL
+                jsr     SETVID
+                jsr     SETKBD
+                jsr     SETNORM
+                jsr     INIT
+                jsr     HOME
+                lda #$f0
+                sta $c022
+                lda #$00
+                sta $c034
+                MLI_CALL QUIT, quit_params
+                brk
+                
+                DEFINE_QUIT_PARAMS quit_params


### PR DESCRIPTION
Utilities for the Apple IIgs or on any Apple II equipped with a VidHD card to set the color of the text, background, and border.