### PR TITLE
Improve Cricket! detection on ROM4 //c

### DIFF
--- a/clocks/cricket/cricket.system.s
+++ b/clocks/cricket/cricket.system.s
@@ -75,6 +75,7 @@ ssc_not_found:
 
         ;; Init SSC and try the "Read Cricket ID code" sequence.
 init_ssc:
+        sei
         lda     COMMAND         ; save status of SSC registers
         sta     saved_command
         lda     CONTROL

--- a/clocks/cricket/cricket.system.s
+++ b/clocks/cricket/cricket.system.s
@@ -75,6 +75,7 @@ ssc_not_found:
 
         ;; Init SSC and try the "Read Cricket ID code" sequence.
 init_ssc:
+        php
         sei
         lda     COMMAND         ; save status of SSC registers
         sta     saved_command
@@ -114,10 +115,12 @@ digit:  cmp     #HI('0')          ; < '0' ?
 
 cricket_found:
         jsr     restore_cmd_ctl
+        plp
         jmp     install_driver
 
 cricket_not_found:
         jsr     restore_cmd_ctl
+        plp
         ;; fall through...
 
 not_found:


### PR DESCRIPTION
Later revisions of the //c ROM set an interrupt when DTR changes state. By turning off interrupts before changing the ACIA settings we can avoid missing detection of responses from the Cricket! (depending on previous state of the register).