### PR TITLE
Jumbo: improve reliability with new chain order

### DIFF
--- a/clocks/jumbo/README.md
+++ b/clocks/jumbo/README.md
@@ -7,7 +7,7 @@ The drivers are (in order):
 * No-Slot Clock
 * ROMX
 * FujiNet
-* DClock
 * Cricket!
+* DClock
 
 The installer is silent - no output is shown on either failure or success.

--- a/clocks/jumbo/clock.system.s
+++ b/clocks/jumbo/clock.system.s
@@ -28,14 +28,14 @@
 .scope romx
         .include "../romx/romxrtc.system.s"
 .endscope
-.scope dclock
-        .include "../dclock/dclock.system.s"
-.endscope
 .scope fujinet
         .include "../fujinet/fn.clock.system.s"
 .endscope
 .scope cricket
         .include "../cricket/cricket.system.s"
+.endscope
+.scope dclock
+        .include "../dclock/dclock.system.s"
 .endscope
 
 ;;; ============================================================
@@ -58,13 +58,13 @@
         jsr     romx::maybe_install_driver
         bcc     ret
 
-        jsr     dclock::maybe_install_driver
-        bcc     ret
-
         jsr     fujinet::maybe_install_driver
         bcc     ret
 
         jsr     cricket::maybe_install_driver
+        bcc     ret
+
+        jsr     dclock::maybe_install_driver
         bcc     ret
 
 ret:    rts


### PR DESCRIPTION
Try DClock driver last due to possible unreliability in detection.